### PR TITLE
feat: allow including chilren in sink [ENG-5531]

### DIFF
--- a/audit_log_feed.tf
+++ b/audit_log_feed.tf
@@ -17,7 +17,7 @@ resource "google_pubsub_topic" "audit_feed" {
 
 resource "google_logging_organization_sink" "organization_audit_feed_with_children" {
   count       = (var.relay_audit_log && var.organization_id != "" && var.audit_log_include_children) ? 1 : 0
-  name        = "${local.prefix}audit-feed"
+  name        = "${local.prefix}audit-feed-with-children"
   description = "Organization level audit logs for Stacklet relay"
 
   org_id           = var.organization_id
@@ -29,7 +29,7 @@ resource "google_logging_organization_sink" "organization_audit_feed_with_childr
 
 resource "google_logging_organization_sink" "organization_audit_feed_without_children" {
   count       = (var.relay_audit_log && var.organization_id != "" && !var.audit_log_include_children) ? 1 : 0
-  name        = "${local.prefix}audit-feed"
+  name        = "${local.prefix}audit-feed-without-children"
   description = "Organization level audit logs for Stacklet relay"
 
   org_id           = var.organization_id
@@ -48,7 +48,7 @@ resource "google_pubsub_topic_iam_member" "organization_feed_publisher" {
 
 resource "google_logging_folder_sink" "folder_feed_with_children" {
   count       = (var.relay_audit_log && var.audit_log_include_children) ? length(var.folder_ids) : 0
-  name        = "${local.prefix}folder-audit-feed-${var.folder_ids[count.index]}"
+  name        = "${local.prefix}folder-audit-feed-${var.folder_ids[count.index]}-with-children"
   description = "Folder level audit logs for Stacklet relay"
 
   folder           = var.folder_ids[count.index]
@@ -60,7 +60,7 @@ resource "google_logging_folder_sink" "folder_feed_with_children" {
 
 resource "google_logging_folder_sink" "folder_feed_without_children" {
   count       = (var.relay_audit_log && !var.audit_log_include_children) ? length(var.folder_ids) : 0
-  name        = "${local.prefix}folder-audit-feed-${var.folder_ids[count.index]}"
+  name        = "${local.prefix}folder-audit-feed-${var.folder_ids[count.index]}-without-children"
   description = "Folder level audit logs for Stacklet relay"
 
   folder           = var.folder_ids[count.index]

--- a/audit_log_feed.tf
+++ b/audit_log_feed.tf
@@ -18,7 +18,7 @@ resource "google_pubsub_topic" "audit_feed" {
 resource "google_logging_organization_sink" "organization_audit_feed_with_children" {
   count       = (var.relay_audit_log && var.organization_id != "" && var.audit_log_include_children) ? 1 : 0
   name        = "${local.prefix}audit-feed-with-children"
-  description = "Organization level audit logs for Stacklet relay"
+  description = "Organization level audit logs for Stacklet relay (with children)"
 
   org_id           = var.organization_id
   filter           = local.audit_filter
@@ -30,7 +30,7 @@ resource "google_logging_organization_sink" "organization_audit_feed_with_childr
 resource "google_logging_organization_sink" "organization_audit_feed_without_children" {
   count       = (var.relay_audit_log && var.organization_id != "" && !var.audit_log_include_children) ? 1 : 0
   name        = "${local.prefix}audit-feed-without-children"
-  description = "Organization level audit logs for Stacklet relay"
+  description = "Organization level audit logs for Stacklet relay (without children)"
 
   org_id           = var.organization_id
   filter           = local.audit_filter

--- a/audit_log_feed.tf
+++ b/audit_log_feed.tf
@@ -7,59 +7,74 @@ locals {
   audit_filter = "logName:\"cloudaudit.googleapis.com%2Factivity\""
 }
 
-# Workaround for https://github.com/hashicorp/terraform-provider-google/issues/10811
-# Force recreation of sinks when include_children changes
-resource "terraform_data" "include_children_trigger" {
-  input = var.audit_log_include_children
-}
-
 resource "google_pubsub_topic" "audit_feed" {
   count = var.relay_audit_log ? 1 : 0
   name  = "${local.prefix}audit-feed"
 }
 
-resource "google_logging_organization_sink" "organization_audit_feed" {
-  count       = (var.relay_audit_log && var.organization_id != "") ? 1 : 0
+# Workaround for https://github.com/hashicorp/terraform-provider-google/issues/10811
+# Separate resources for include_children true/false to force recreation on change
+
+resource "google_logging_organization_sink" "organization_audit_feed_with_children" {
+  count       = (var.relay_audit_log && var.organization_id != "" && var.audit_log_include_children) ? 1 : 0
   name        = "${local.prefix}audit-feed"
   description = "Organization level audit logs for Stacklet relay"
 
   org_id           = var.organization_id
   filter           = local.audit_filter
-  include_children = var.audit_log_include_children
+  include_children = true
 
   destination = "pubsub.googleapis.com/${google_pubsub_topic.audit_feed[0].id}"
-
-  lifecycle {
-    replace_triggered_by = [terraform_data.include_children_trigger]
-  }
 }
+
+resource "google_logging_organization_sink" "organization_audit_feed_without_children" {
+  count       = (var.relay_audit_log && var.organization_id != "" && !var.audit_log_include_children) ? 1 : 0
+  name        = "${local.prefix}audit-feed"
+  description = "Organization level audit logs for Stacklet relay"
+
+  org_id           = var.organization_id
+  filter           = local.audit_filter
+  include_children = false
+
+  destination = "pubsub.googleapis.com/${google_pubsub_topic.audit_feed[0].id}"
+}
+
 resource "google_pubsub_topic_iam_member" "organization_feed_publisher" {
   count  = (var.relay_audit_log && var.organization_id != "") ? 1 : 0
   topic  = google_pubsub_topic.audit_feed[0].name
   role   = "roles/pubsub.publisher"
-  member = google_logging_organization_sink.organization_audit_feed[0].writer_identity
+  member = var.audit_log_include_children ? google_logging_organization_sink.organization_audit_feed_with_children[0].writer_identity : google_logging_organization_sink.organization_audit_feed_without_children[0].writer_identity
 }
 
-resource "google_logging_folder_sink" "folder_feed" {
-  count       = var.relay_audit_log ? length(var.folder_ids) : 0
+resource "google_logging_folder_sink" "folder_feed_with_children" {
+  count       = (var.relay_audit_log && var.audit_log_include_children) ? length(var.folder_ids) : 0
   name        = "${local.prefix}folder-audit-feed-${var.folder_ids[count.index]}"
   description = "Folder level audit logs for Stacklet relay"
 
   folder           = var.folder_ids[count.index]
   filter           = local.audit_filter
-  include_children = var.audit_log_include_children
+  include_children = true
 
   destination = "pubsub.googleapis.com/${google_pubsub_topic.audit_feed[0].id}"
-
-  lifecycle {
-    replace_triggered_by = [terraform_data.include_children_trigger]
-  }
 }
+
+resource "google_logging_folder_sink" "folder_feed_without_children" {
+  count       = (var.relay_audit_log && !var.audit_log_include_children) ? length(var.folder_ids) : 0
+  name        = "${local.prefix}folder-audit-feed-${var.folder_ids[count.index]}"
+  description = "Folder level audit logs for Stacklet relay"
+
+  folder           = var.folder_ids[count.index]
+  filter           = local.audit_filter
+  include_children = false
+
+  destination = "pubsub.googleapis.com/${google_pubsub_topic.audit_feed[0].id}"
+}
+
 resource "google_pubsub_topic_iam_member" "folder_feed_publisher" {
   count  = var.relay_audit_log ? length(var.folder_ids) : 0
   topic  = google_pubsub_topic.audit_feed[0].name
   role   = "roles/pubsub.publisher"
-  member = google_logging_folder_sink.folder_feed[count.index].writer_identity
+  member = var.audit_log_include_children ? google_logging_folder_sink.folder_feed_with_children[count.index].writer_identity : google_logging_folder_sink.folder_feed_without_children[count.index].writer_identity
 }
 
 resource "google_logging_project_sink" "project_feed" {

--- a/audit_log_feed.tf
+++ b/audit_log_feed.tf
@@ -17,8 +17,9 @@ resource "google_logging_organization_sink" "organization_audit_feed" {
   name        = "${local.prefix}audit-feed"
   description = "Organization level audit logs for Stacklet relay"
 
-  org_id = var.organization_id
-  filter = local.audit_filter
+  org_id           = var.organization_id
+  filter           = local.audit_filter
+  include_children = var.audit_log_include_children
 
   destination = "pubsub.googleapis.com/${google_pubsub_topic.audit_feed[0].id}"
 }
@@ -34,8 +35,9 @@ resource "google_logging_folder_sink" "folder_feed" {
   name        = "${local.prefix}folder-audit-feed-${var.folder_ids[count.index]}"
   description = "Folder level audit logs for Stacklet relay"
 
-  folder = var.folder_ids[count.index]
-  filter = local.audit_filter
+  folder           = var.folder_ids[count.index]
+  filter           = local.audit_filter
+  include_children = var.audit_log_include_children
 
   destination = "pubsub.googleapis.com/${google_pubsub_topic.audit_feed[0].id}"
 }

--- a/vars.tf
+++ b/vars.tf
@@ -42,6 +42,12 @@ variable "relay_security_command_center_findings" {
   description = "Controls whether or not security command center findings are forwarded - required for 'gcp-scc' policies."
 }
 
+variable "audit_log_include_children" {
+  type        = bool
+  default     = false
+  description = "Controls whether audit log sinks include logs from child resources (folders/projects)."
+}
+
 #
 #  Additional variables
 #


### PR DESCRIPTION
[ENG-5531](https://stacklet.atlassian.net/browse/ENG-5531)

### what

If you setup a sink without including the children it will only give logs for resources directly in the root of the folder and not any subfolders.

I had to structure it in a more complicated way because of this bug:
- https://github.com/hashicorp/terraform-provider-google/issues/10811

### why

Sometimes customers want a simple setup with all resources within a folder to feed the log.

### testing

I setup a relay with this code:
- https://github.com/stacklet/sontek/pull/8/files

and proved it work by creating compute instances and seeing it trigger on the AWS side:

<img width="718" height="767" alt="Screen Shot 2025-10-01 at 4 52 34 PM" src="https://github.com/user-attachments/assets/f0c9689b-1b56-458e-93bf-55c669437e2c" />

with this PR the TF plan was:

```
# module.stacklet_relay.google_logging_folder_sink.folder_feed[0] will be updated in-place
  ~ resource "google_logging_folder_sink" "folder_feed" {
        id                 = "folders/492199171560/sinks/folder-audit-feed-492199171560"
      ~ include_children   = false -> true
        name               = "folder-audit-feed-492199171560"
        # (7 unchanged attributes hidden)
    }
```

### docs

Docs are in the PR


[ENG-5531]: https://stacklet.atlassian.net/browse/ENG-5531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ